### PR TITLE
Add simple frontend for scraping backend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,28 @@
+# Frontend for Scraping Backend
+
+This is a lightweight web interface for triggering and viewing data from the scraping backend.
+
+## Development
+
+Open `index.html` in a browser. The frontend expects the backend API to be available at `http://localhost:8000`:
+
+- `POST /scrape` — inicia el scraping.
+- `GET /data` — devuelve los datos scrapeados en formato JSON.
+
+Ajusta la constante `API_BASE` en `main.js` según la URL donde esté desplegado tu backend.
+
+## Deployment
+
+Los archivos son estáticos y pueden alojarse fácilmente en **GitHub Pages** o **Supabase**:
+
+### GitHub Pages
+
+1. Copia la carpeta `frontend` a tu repositorio público.
+2. En la configuración del repositorio, habilita GitHub Pages seleccionando la rama y el directorio `/frontend`.
+3. Accede al sitio desde `https://<usuario>.github.io/<repositorio>/`.
+
+### Supabase
+
+1. Crea un bucket de almacenamiento público.
+2. Sube los archivos de `frontend` al bucket.
+3. Sirve el contenido directamente desde Supabase o mediante una función edge.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scraping Dashboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-gray-100 min-h-screen">
+    <div class="container mx-auto py-8">
+      <h1 class="text-3xl font-bold mb-4 text-center">Scraping Dashboard</h1>
+      <div class="flex justify-center space-x-4 mb-6">
+        <button
+          id="run-scraping"
+          class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+        >
+          Run Scraping
+        </button>
+        <button
+          id="refresh-data"
+          class="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"
+        >
+          Refresh Data
+        </button>
+      </div>
+      <div id="message" class="text-center mb-4"></div>
+      <table class="min-w-full bg-white" id="data-table">
+        <thead>
+          <tr>
+            <th class="py-2 px-4 border-b">Fecha</th>
+            <th class="py-2 px-4 border-b">Causa</th>
+            <th class="py-2 px-4 border-b">Link</th>
+          </tr>
+        </thead>
+        <tbody id="data-body"></tbody>
+      </table>
+    </div>
+    <script src="main.js"></script>
+  </body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,46 @@
+const API_BASE = "http://localhost:8000"; // adjust to your backend URL
+
+async function fetchData() {
+  const msg = document.getElementById("message");
+  try {
+    const response = await fetch(`${API_BASE}/data`);
+    if (!response.ok) throw new Error("Network response was not ok");
+    const data = await response.json();
+    const tbody = document.getElementById("data-body");
+    tbody.innerHTML = "";
+    data.forEach((row) => {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `
+        <td class="py-2 px-4 border-b">${row.Fecha || ""}</td>
+        <td class="py-2 px-4 border-b">${row.Causa || ""}</td>
+        <td class="py-2 px-4 border-b"><a class="text-blue-500 underline" href="${row.Link || "#"}" target="_blank">Ver</a></td>
+      `;
+      tbody.appendChild(tr);
+    });
+    msg.textContent = "";
+  } catch (error) {
+    msg.textContent = "Error obteniendo datos.";
+  }
+}
+
+async function runScraping() {
+  const msg = document.getElementById("message");
+  msg.textContent = "Ejecutando scraping...";
+  try {
+    const response = await fetch(`${API_BASE}/scrape`, { method: "POST" });
+    if (response.ok) {
+      msg.textContent = "Scraping iniciado correctamente.";
+      await fetchData();
+    } else {
+      msg.textContent = "Error al iniciar scraping.";
+    }
+  } catch (error) {
+    msg.textContent = "Error al iniciar scraping.";
+  }
+}
+
+document.getElementById("run-scraping").addEventListener("click", runScraping);
+document.getElementById("refresh-data").addEventListener("click", fetchData);
+
+// Initial load
+fetchData();


### PR DESCRIPTION
## Summary
- add Tailwind-based dashboard with buttons to trigger scraping and refresh data
- fetch API to backend and display results
- document how to host on GitHub Pages or Supabase

## Testing
- `python -m py_compile scraping_backend.py`
- `npx prettier --check frontend/index.html frontend/main.js frontend/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68912a10ada48329974c7716d16067bd