### PR TITLE
feat: make API base configurable

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,12 +4,30 @@ This is a lightweight web interface for triggering and viewing data from the scr
 
 ## Development
 
-Open `index.html` in a browser. The frontend expects the backend API to be available at `http://localhost:8000`:
+Open `index.html` in a browser. The frontend expects the backend API to provide:
 
 - `POST /scrape` — inicia el scraping.
 - `GET /data` — devuelve los datos scrapeados en formato JSON.
 
-Ajusta la constante `API_BASE` en `main.js` según la URL donde esté desplegado tu backend.
+### Configuración de `API_BASE`
+
+El URL del backend se determina en tiempo de ejecución siguiendo este orden:
+
+1. Valor almacenado en `localStorage` bajo la clave `API_BASE`.
+2. Variable global `window.API_BASE` (definida en `config.js` o inyectada directamente en `index.html`).
+3. Valor por defecto `""` (relativo), útil cuando frontend y backend comparten origen.
+
+Ejemplo en la consola del navegador para apuntar a un backend local:
+
+```js
+localStorage.setItem('API_BASE', 'http://localhost:8000');
+```
+
+También puedes editar `config.js` y establecer:
+
+```js
+window.API_BASE = 'http://localhost:8000';
+```
 
 ## Deployment
 
@@ -19,10 +37,12 @@ Los archivos son estáticos y pueden alojarse fácilmente en **GitHub Pages** o 
 
 1. Copia la carpeta `frontend` a tu repositorio público.
 2. En la configuración del repositorio, habilita GitHub Pages seleccionando la rama y el directorio `/frontend`.
-3. Accede al sitio desde `https://<usuario>.github.io/<repositorio>/`.
+3. Ajusta `config.js` para apuntar a tu backend (por ejemplo, `window.API_BASE = 'https://tu-backend.example.com';`).
+4. Accede al sitio desde `https://<usuario>.github.io/<repositorio>/`.
 
 ### Supabase
 
 1. Crea un bucket de almacenamiento público.
 2. Sube los archivos de `frontend` al bucket.
-3. Sirve el contenido directamente desde Supabase o mediante una función edge.
+3. Edita `config.js` con la URL de tu backend.
+4. Sirve el contenido directamente desde Supabase o mediante una función edge.

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,0 +1,3 @@
+// Override API_BASE here or via localStorage
+// e.g., window.API_BASE = 'https://api.example.com';
+window.API_BASE = window.API_BASE || "";

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -35,6 +35,7 @@
         <tbody id="data-body"></tbody>
       </table>
     </div>
+    <script src="config.js"></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,4 +1,7 @@
-const API_BASE = "http://localhost:8000"; // adjust to your backend URL
+const API_BASE =
+  window.localStorage.getItem("API_BASE") ||
+  window.API_BASE ||
+  ""; // defaults to relative URLs
 
 async function fetchData() {
   const msg = document.getElementById("message");


### PR DESCRIPTION
## Summary
- allow frontend to read API base from `localStorage` or a global `API_BASE` variable with relative default
- document how to set `API_BASE` for local use, GitHub Pages, or Supabase deployments

## Testing
- `node --check frontend/main.js`
- `node --check frontend/config.js`
- `python -m py_compile scraping_backend.py`


------
https://chatgpt.com/codex/tasks/task_e_689682fa286c8329b53fbdb4e1fb3ddb