### PR TITLE
refactor: build rows with DOM API and sanitize backend

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -10,11 +10,27 @@ async function fetchData() {
     tbody.innerHTML = "";
     data.forEach((row) => {
       const tr = document.createElement("tr");
-      tr.innerHTML = `
-        <td class="py-2 px-4 border-b">${row.Fecha || ""}</td>
-        <td class="py-2 px-4 border-b">${row.Causa || ""}</td>
-        <td class="py-2 px-4 border-b"><a class="text-blue-500 underline" href="${row.Link || "#"}" target="_blank">Ver</a></td>
-      `;
+
+      const tdFecha = document.createElement("td");
+      tdFecha.className = "py-2 px-4 border-b";
+      tdFecha.textContent = row.Fecha || "";
+      tr.appendChild(tdFecha);
+
+      const tdCausa = document.createElement("td");
+      tdCausa.className = "py-2 px-4 border-b";
+      tdCausa.textContent = row.Causa || "";
+      tr.appendChild(tdCausa);
+
+      const tdLink = document.createElement("td");
+      tdLink.className = "py-2 px-4 border-b";
+      const link = document.createElement("a");
+      link.className = "text-blue-500 underline";
+      link.textContent = "Ver";
+      link.setAttribute("href", row.Link || "#");
+      link.setAttribute("target", "_blank");
+      tdLink.appendChild(link);
+      tr.appendChild(tdLink);
+
       tbody.appendChild(tr);
     });
     msg.textContent = "";

--- a/scraping_backend.py
+++ b/scraping_backend.py
@@ -7,6 +7,7 @@ import os
 import glob
 import pandas as pd
 from datetime import datetime, timedelta
+import html
 
 # Selenium y BeautifulSoup
 from selenium import webdriver
@@ -79,6 +80,13 @@ def normalize_causa(causa_str):
     if not isinstance(causa_str, str):
         return "unknown_causa"
     return causa_str.replace(" ", "").replace("/", "_").replace("-", "_").lower()
+
+
+def sanitize_text(value):
+    """Escapa cualquier HTML en los campos de texto."""
+    if not isinstance(value, str):
+        return value
+    return html.escape(value)
 
 
 ########################################
@@ -199,12 +207,13 @@ def scrapingPJN(dni_usuario):
                         f"Advertencia: No se encontró 'Causa' o 'Nombre' en una fila para {perito_nombre}. Fila: {element_tr.get_text(strip=True, separator=' | ')}")
                     continue
 
-                causa = causa_elem.text.strip()
-                nombre = nombre_elem.text.strip()
+                causa = sanitize_text(causa_elem.text.strip())
+                nombre = sanitize_text(nombre_elem.text.strip())
 
                 # Extraer link (aria-label='Ver Causa')
                 link_elem = element_tr.find("a", attrs={"aria-label": "Ver Causa"})
-                link = link_elem.get("href", "") if link_elem else ""
+                link_raw = link_elem.get("href", "") if link_elem else ""
+                link = sanitize_text(link_raw)
 
                 # Mapeo de Tipo
                 tipo_mapeado = "NOVEDAD"
@@ -224,8 +233,8 @@ def scrapingPJN(dni_usuario):
                     # Por ahora, la fila se incluirá con Fecha=None, que luego se manejará.
 
                 row = {
-                    "Perito": perito_nombre,  # Usar el nombre completo del perito
-                    "Tipo": tipo_mapeado,
+                    "Perito": sanitize_text(perito_nombre),  # Usar el nombre completo del perito
+                    "Tipo": sanitize_text(tipo_mapeado),
                     "Causa": causa,
                     "Nombre": nombre,
                     "Fecha": fecha_dt,  # Guardar como objeto datetime
@@ -298,6 +307,11 @@ def saveToFirestore(rows_data):
                 data_to_save["Fecha"] = data_to_save["Fecha"]  # Firestore maneja datetime directamente
             if isinstance(data_to_save.get("ScrapedAt"), datetime):
                 data_to_save["ScrapedAt"] = data_to_save["ScrapedAt"]
+
+            # Sanitizar cualquier cadena antes de guardar
+            for k, v in list(data_to_save.items()):
+                if isinstance(v, str):
+                    data_to_save[k] = sanitize_text(v)
 
             # Añadir campos de control/estado por defecto si no existen
             if 'Aceptada' not in data_to_save:


### PR DESCRIPTION
## Summary
- avoid HTML rendering by constructing DOM elements and setting text/attributes
- escape textual fields on the backend before persistence

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m py_compile scraping_backend.py`


------
https://chatgpt.com/codex/tasks/task_e_689682fa4480832985df42b0214e1445